### PR TITLE
changes default behavior to export all exported types

### DIFF
--- a/lib/bin/ts-to-openapi.ts
+++ b/lib/bin/ts-to-openapi.ts
@@ -92,6 +92,7 @@ const parsed = oppa( {
 	name: "types",
 	alias: "t",
 	type: "string",
+	default: "*",
 	description: "The types to convert to OpenAPI",
 } )
 .parse( );


### PR DESCRIPTION
I submit a small proposed change to capture all exported types in a file if no -t is specified. This is backwards compatible outside of making a previously invalid invocation now valid.

Our use case for this is that we've decided to move all REST-layer interfaces into a single file of our project. With this change to the tool, as we add new types to that file and they're automatically ingested into our API spec via automation.